### PR TITLE
Add Github actions manifests for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: ci
+
+on:
+  push:
+    tags:
+    - v*
+    branches:
+    - master
+  pull_request:
+    branches: [master]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v1
+      with:
+        version: v1.29
+
+  go_test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.14.6'
+    - run: go test ./...


### PR DESCRIPTION
This adds CI jobs for linting https://github.com/golangci/golangci-lint-action and running tests https://github.com/actions/setup-go

Related #3

Signed-off-by: Oluwole Fadeyi <oluwolefadeyi@gmail.com>